### PR TITLE
UsbStream now accepts GUID with device interface class

### DIFF
--- a/System.Device.UsbStream/UsbStream.cs
+++ b/System.Device.UsbStream/UsbStream.cs
@@ -33,9 +33,14 @@ namespace System.Device.UsbClient
         /// <exception cref="PlatformNotSupportedException">This is not support in .NET nanoFramework.</exception>
         public override long Position { get => throw new PlatformNotSupportedException(); set => throw new PlatformNotSupportedException(); }
 
-        internal UsbStream(string name)
+        internal UsbStream(
+            Guid classId,
+            string name)
         {
-            _streamIndex = NativeOpen(name);
+            // need to convert GUID to proper format to help processing at native end
+            _streamIndex = NativeOpen(
+                $"{{{classId}}}",
+                name);
 
             _disposed = false;
         }
@@ -106,7 +111,7 @@ namespace System.Device.UsbClient
         private extern void NativeClose();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern int NativeOpen(string name);
+        private extern int NativeOpen(string classId, string name);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern void NativeWrite(byte[] buffer, int offset, int count);

--- a/UsbClient/UsbClient.cs
+++ b/UsbClient/UsbClient.cs
@@ -11,11 +11,16 @@ namespace System.Device.UsbClient
         /// <summary>
         /// Creates an USB Stream from a WinUSB device that will use the specified name as the device description.
         /// </summary>
+        /// <param name="classId"><see cref="Guid"/> for the device class that will be used by WinUSB device.</param>
         /// <param name="name">Name to be used as device description.</param>
         /// <returns>A new UsbStream that was created with the specified name.</returns>
-        public static UsbStream CreateUsbStream(string name)
+        public static UsbStream CreateUsbStream(
+            Guid classId,
+            string name)
         {
-            return new UsbStream(name);
+            return new UsbStream(
+                classId,
+                name);
         }
     }
 }


### PR DESCRIPTION
## Description
- Add parameter accepting device interface GUID. 
- Passing this to native.

## Motivation and Context
- Allows application to configure device interface GUID for WinUSB enumeration.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
